### PR TITLE
Update lxml to 4.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic==1.3.3
 Scrapy==1.7.3
-lxml==4.2.4
+lxml==4.6.1
 requests==2.20.0
 wget==3.2
 xlrd==1.1.0


### PR DESCRIPTION
This is to get a working `pip install` on macOS
with Python3.9.1 again