### PR TITLE
[HB] Exit early if page contains no data

### DIFF
--- a/jedeschule/spiders/bremen.py
+++ b/jedeschule/spiders/bremen.py
@@ -19,6 +19,11 @@ class BremenSpider(SchoolSpider):
 
     def parse_detail(self, response):
         lis = response.css(".kogis_main_visitenkarte ul li")
+
+        if len(lis) == 0:
+            # Detail page contains no info, see https://github.com/Datenschule/jedeschule-scraper/issues/54
+            return
+
         collection = {}
         collection['id'] = response.meta['id'].zfill(3)
         collection['name'] = response.css(".main_article h3 ::text").extract_first()


### PR DESCRIPTION
We used to have this logic already for this scraper but
it got lost with the last merge. Note that in this commit
we return None instead of raising a `DropItem` (as we did
in the initial implementation) because we want to silently
drop this item as opposed to treating it like an error.