### PR TITLE
Convert NRW code to proper scraper

### DIFF
--- a/jedeschule/spiders/hamburg.py
+++ b/jedeschule/spiders/hamburg.py
@@ -1,4 +1,5 @@
-from lxml import etree
+import xml.etree.ElementTree as ET
+
 from scrapy import Item
 
 from jedeschule.spiders.school_spider import SchoolSpider
@@ -11,7 +12,7 @@ class HamburgSpider(SchoolSpider):
     start_urls = ['https://geoportal-hamburg.de/geodienste_hamburg_de/HH_WFS_Schulen?REQUEST=GetFeature&SERVICE=WFS&SRSNAME=EPSG%3A25832&TYPENAME=staatliche_schulen&VERSION=1.1.0']
 
     def parse(self, response):
-        elem = etree.fromstring(response.body)
+        elem = ET.fromstring(response.body)
 
         for member in elem:
             data_elem = {}

--- a/jedeschule/spiders/nordrhein_westfalen.py
+++ b/jedeschule/spiders/nordrhein_westfalen.py
@@ -2,6 +2,7 @@ from csv import DictReader
 
 from scrapy import Item
 
+from jedeschule.spiders.nordrhein_westfalen_helper import NordRheinWestfalenHelper
 from jedeschule.spiders.school_spider import SchoolSpider
 from jedeschule.items import School
 
@@ -33,9 +34,7 @@ class NordrheinWestfalenSpider(SchoolSpider):
         name = "".join([item.get("Schulbezeichnung_1", ""),
                         item.get("Schulbezeichnung_2", ""),
                         item.get("Schulbezeichnung_3", "")])
-        # TODO: Get school type by also loading the mapping table from
-        # here https://www.schulministerium.nrw.de/BiPo/OpenData/Schuldaten/key_schulformschluessel.csv
-        # and then joining the results
+        helper = NordRheinWestfalenHelper()
         return School(name=name,
                       id='NW-{}'.format(item.get('Schulnummer')),
                       address=item.get('Strasse'),
@@ -43,5 +42,7 @@ class NordrheinWestfalenSpider(SchoolSpider):
                       city=item.get('Ort'),
                       website=item.get('Homepage'),
                       email=item.get('E-Mail'),
+                      legal_status=helper.resolve('rechtsform', item.get('Rechtsform')),
+                      school_type=helper.resolve('schulform', item.get('Schulform')),
                       fax=f"{item.get('Faxvorwahl')}{item.get('Fax')}",
                       phone=f"{item.get('Telefonvorwahl')}{item.get('Telefon')}")

--- a/jedeschule/spiders/nordrhein_westfalen.py
+++ b/jedeschule/spiders/nordrhein_westfalen.py
@@ -1,0 +1,47 @@
+from csv import DictReader
+
+from scrapy import Item
+
+from jedeschule.spiders.school_spider import SchoolSpider
+from jedeschule.items import School
+
+# for an overview of the data provided by the State of
+# Nordrhein-Westfalen, check out the overview page here:
+# https://www.schulministerium.nrw.de/ministerium/open-government/offene-daten
+
+
+class NordrheinWestfalenSpider(SchoolSpider):
+    name = 'nordrhein-westfalen'
+
+    start_urls = [
+        'https://www.schulministerium.nrw.de/BiPo/OpenData/Schuldaten/schuldaten.csv',
+    ]
+
+    def parse(self, response):
+        # TODO: This data provider actually provides coordinate values that
+        # we can use at a later point. Extract them from here so that we don't
+        # have to fall back to geocoding
+
+        body = response.body.decode('utf-8').splitlines()
+        # skip the first line which contains information about the separator
+        reader = DictReader(body[1:], delimiter=';')
+        for line in reader:
+            yield line
+
+    @staticmethod
+    def normalize(item: Item) -> School:
+        name = "".join([item.get("Schulbezeichnung_1", ""),
+                        item.get("Schulbezeichnung_2", ""),
+                        item.get("Schulbezeichnung_3", "")])
+        # TODO: Get school type by also loading the mapping table from
+        # here https://www.schulministerium.nrw.de/BiPo/OpenData/Schuldaten/key_schulformschluessel.csv
+        # and then joining the results
+        return School(name=name,
+                      id='NW-{}'.format(item.get('Schulnummer')),
+                      address=item.get('Strasse'),
+                      zip=item.get("PLZ"),
+                      city=item.get('Ort'),
+                      website=item.get('Homepage'),
+                      email=item.get('E-Mail'),
+                      fax=f"{item.get('Faxvorwahl')}{item.get('Fax')}",
+                      phone=f"{item.get('Telefonvorwahl')}{item.get('Telefon')}")

--- a/jedeschule/spiders/nordrhein_westfalen_helper.py
+++ b/jedeschule/spiders/nordrhein_westfalen_helper.py
@@ -1,0 +1,42 @@
+import csv
+
+import requests
+
+
+# See https://www.python.org/dev/peps/pep-0318/#examples
+def singleton(cls):
+    instances = {}
+    def getinstance():
+        if cls not in instances:
+            instances[cls] = cls()
+        return instances[cls]
+    return getinstance
+
+
+@singleton
+class NordRheinWestfalenHelper:
+    sources = {
+        "rechtsform": "https://www.schulministerium.nrw.de/BiPo/OpenData/Schuldaten/key_rechtsform.csv",
+        "schulform": "https://www.schulministerium.nrw.de/BiPo/OpenData/Schuldaten/key_schulformschluessel.csv"
+    }
+
+    def __init__(self):
+        self.mappings = self.load_data()
+
+    def load_data(self):
+        return {
+            key: self.get_map(url)
+            for key, url in self.sources.items()
+        }
+
+    def get_map(self, url):
+        response = requests.get(url)
+        response.encoding = 'utf-8'
+        # skip the first line which contains information about
+        # the separator
+        # and the second line which contains the headers
+        reader = csv.reader(response.text.splitlines()[2:], delimiter=';')
+        return {line[0]: line[1] for line in reader}
+
+    def resolve(self, data_type, key):
+        return self.mappings.get(data_type).get(key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 alembic==1.3.3
 Scrapy==1.7.3
-lxml==4.2.4
 requests==2.20.0
 wget==3.2
 xlrd==1.1.0

--- a/run.py
+++ b/run.py
@@ -1,15 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import csv
 import json
 import os
-from io import StringIO
-from urllib.parse import urljoin
 
 import wget
 import xlrd
-import requests
-from lxml import etree
 
 from twisted.internet import reactor, defer
 from scrapy.crawler import CrawlerRunner
@@ -115,79 +110,6 @@ def get_mv():
         json_file.write(json.dumps(data))
     os.remove(filename)
 
-
-def __retrieve_keys(url):
-    r = requests.get(url)
-    r.encoding = 'utf-8'
-
-    sio = StringIO(r.content.decode('utf-8'))
-    sb_csv = csv.reader(sio, delimiter=';')
-
-    # Skip the first two lines
-    next(sb_csv)
-    next(sb_csv)
-
-    result = {row[0]: row[1] for row in sb_csv}
-    return result
-
-
-def __retrieve_xml(url):
-    r = requests.get(url)
-    r.encoding = 'utf-8'
-    elem = etree.fromstring(r.content)
-    data = []
-    for member in elem:
-        data_elem = {}
-        for attr in member:
-            data_elem[attr.tag] = attr.text
-
-        data.append(data_elem)
-
-    return data
-
-
-def get_nrw():
-    base_url_nrw = 'https://www.schulministerium.nrw.de/BiPo/OpenData/Schuldaten/'
-
-    schulbetrieb = __retrieve_keys(urljoin(base_url_nrw, 'key_schulbetriebsschluessel.csv'))
-    schulform = __retrieve_keys(urljoin(base_url_nrw, 'key_schulformschluessel.csv'))
-    rechtsform = __retrieve_keys(urljoin(base_url_nrw, 'key_rechtsform.csv'))
-    schuelerzahl = __retrieve_keys(urljoin(base_url_nrw, 'SchuelerGesamtZahl/anzahlen.csv'))
-
-    traeger_raw = __retrieve_xml(urljoin(base_url_nrw, 'key_traeger.xml'))
-    traeger = {x['Traegernummer']: x for x in traeger_raw}
-
-    r = requests.get(urljoin(base_url_nrw, 'schuldaten.xml'))
-    r.encoding = 'utf-8'
-    elem = etree.fromstring(r.content)
-    data = []
-    for member in elem:
-        data_elem = {}
-
-        for attr in member:
-            data_elem[attr.tag] = attr.text
-
-            if attr.tag == 'Schulnummer':
-                data_elem['Schuelerzahl'] = schuelerzahl.get(attr.text)
-
-            if attr.tag == 'Schulbetriebsschluessel':
-                data_elem['Schulbetrieb'] = schulbetrieb[attr.text]
-
-            if attr.tag == 'Schulform':
-                data_elem['Schulformschluessel'] = attr.text
-                data_elem['Schulform'] = schulform[attr.text]
-
-            if attr.tag == 'Rechtsform':
-                data_elem['Rechtsformschluessel'] = attr.text
-                data_elem['Rechtsform'] = rechtsform[attr.text]
-
-            if attr.tag == 'Traegernummer':
-                data_elem['Traeger'] = traeger.get(attr.text)
-
-        data.append(data_elem)
-    print('Parsed ' + str(len(data)) + ' data elements')
-    with open('data/nrw.json', 'w', encoding='utf-8') as json_file:
-        json_file.write(json.dumps(data))
 
 @defer.inlineCallbacks
 def crawl():


### PR DESCRIPTION
This has two benefits
1. We get data for NRW again (also: this is open data which makes loading the data really trivial)
2. We can remove the lxml dependency entirely which would always take a long time to build the wheels in our docker deployments.