### PR TITLE
Fix test changes workflow

### DIFF
--- a/.github/workflows/test_scraper_changes.yml
+++ b/.github/workflows/test_scraper_changes.yml
@@ -8,6 +8,8 @@ jobs:
     name: Show changes in scraper results
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup python
         uses: actions/setup-python@v1
         with:

--- a/jedeschule/pipelines/db_pipeline.py
+++ b/jedeschule/pipelines/db_pipeline.py
@@ -11,9 +11,14 @@ from jedeschule.items import School
 from jedeschule.pipelines.school_pipeline import SchoolPipelineItem
 
 Base = declarative_base()
-engine = create_engine(os.environ.get("DATABASE_URL"), echo=False)
-Session = sessionmaker(bind=engine)
-session = Session()
+
+
+def get_session():
+    engine = create_engine(os.environ.get("DATABASE_URL"), echo=False)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    return session
 
 
 class School(Base):
@@ -36,6 +41,8 @@ class School(Base):
 
     @staticmethod
     def update_or_create(item: SchoolPipelineItem) -> School:
+        session = get_session()
+
         school = session.query(School).get(item.info['id'])
         if school:
             session.query(School).filter_by(id=item.info['id']).update({**item.info, 'raw': item.item})
@@ -48,6 +55,7 @@ class DatabasePipeline(object):
     def process_item(self, item, spider):
         school = School.update_or_create(item)
         try:
+            session = get_session()
             session.add(school)
             session.commit()
         except SQLAlchemyError as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic==1.3.3
-Scrapy==1.7.3
+Scrapy==2.4.1
 requests==2.20.0
 wget==3.2
 xlrd==1.1.0

--- a/test_changes.py
+++ b/test_changes.py
@@ -46,12 +46,15 @@ def main():
     data = load_data()
     for school in data[:10]:
         school_id = school.get('info').get('id')
+
+        upstream_data = {}
         try:
             upstream_data = fetch_data(school_id)
             upstream_data.pop('raw')
-            compare_schools(school.get('info'), upstream_data)
-        except HTTPError:
-            print(f"Could not fetch old data for school-id {school_id}")
+        except HTTPError as e:
+            print(f"Could not fetch old data for school-id {school_id}: {e}")
+
+        compare_schools(school.get('info'), upstream_data)
 
 
 if __name__ == "__main__":

--- a/test_changes.py
+++ b/test_changes.py
@@ -24,8 +24,6 @@ def get_clean_item(data):
 
 
 def compare_schools(new_school, old_school):
-    print()
-    print(f"Comparing {new_school.get('id')}")
     new_school = sort_dict(new_school)
     old_school = sort_dict(old_school)
 
@@ -47,12 +45,16 @@ def main():
     for school in data[:10]:
         school_id = school.get('info').get('id')
 
+        print()
+        print('#'*10, f'Comparing {school_id}')
+
         upstream_data = {}
         try:
             upstream_data = fetch_data(school_id)
             upstream_data.pop('raw')
         except HTTPError as e:
-            print(f"Could not fetch old data for school-id {school_id}: {e}")
+            print(f"WARN: Could not fetch old data for school-id {school_id}: {e}")
+            print()
 
         compare_schools(school.get('info'), upstream_data)
 

--- a/test_changes.sh
+++ b/test_changes.sh
@@ -2,7 +2,16 @@
 
 set -e
 
-CHANGED_SCRAPERS=$(git whatchanged --name-only --pretty="" origin..HEAD  |
+if [ $CI ]
+then
+  HEAD_REF=${GITHUB_REF}
+else
+  HEAD_REF="HEAD"
+fi
+
+echo "Using head reference: ${HEAD_REF}"
+
+CHANGED_SCRAPERS=$(git whatchanged --name-only --pretty="" origin/master..${HEAD_REF}  |
                   grep spiders |
                   grep -v helper |
                   sed 's/jedeschule\/spiders\///' |

--- a/test_models.py
+++ b/test_models.py
@@ -7,7 +7,7 @@ from scrapy.item import Field
 
 from jedeschule.items import School
 from jedeschule.pipelines.school_pipeline import SchoolPipelineItem
-from jedeschule.pipelines.db_pipeline import School as DBSchool, session
+from jedeschule.pipelines.db_pipeline import School as DBSchool, get_session
 
 
 class TestSchoolItem(Item):
@@ -23,6 +23,7 @@ class TestSchool(unittest.TestCase):
         item = dict(name='Test Schule', nr=1)
         school_item: SchoolPipelineItem = SchoolPipelineItem(info=info, item=item)
         db_item = DBSchool.update_or_create(school_item)
+        session = get_session()
         session.add(db_item)
         session.commit()
 
@@ -40,6 +41,7 @@ class TestSchool(unittest.TestCase):
         item = dict(name='Test Schule', nr=1)
         school_item: SchoolPipelineItem = SchoolPipelineItem(info=info, item=item)
         db_item = DBSchool.update_or_create(school_item)
+        session = get_session()
         session.add(db_item)
         session.commit()
 


### PR DESCRIPTION
Follow-up to PR #61.

The previous PR had some issues:

1.  `git whatchanged` failed because `actions/checkout@v2` only checks out the latest commit by default. Fixed by setting `fetch-depth` to `0` in order to check out the full history. (In the unforeseeable future, there might be a `fetch-refs` option to optimize this, see actions/checkout#155)
2. the scrapy version was too old and did not have the `--overwrite-output` option that is used in `test_changes.sh`
3. `database_pipeline.py` created a session during load time, which complicates things when we do not actually need the DatabasePipeline. refactored session creation into the `get_session()` method to be more flexible here.
  @k-nut : Please take a closer look at the session management (67911825907c47c76bcd17685d7a9bc6af426508). I do have the feeling that our session handling could be improved (i, e. using a fewer number of opened sessions overall).
4. improved `test_changes.py`(!) so that its output is helpful in more cases