### PR TITLE
Create only one session in db_pipeline

### DIFF
--- a/jedeschule/pipelines/db_pipeline.py
+++ b/jedeschule/pipelines/db_pipeline.py
@@ -21,6 +21,9 @@ def get_session():
     return session
 
 
+session = get_session()
+
+
 class School(Base):
     __tablename__ = 'schools'
     id = Column(String, primary_key=True)
@@ -41,8 +44,6 @@ class School(Base):
 
     @staticmethod
     def update_or_create(item: SchoolPipelineItem) -> School:
-        session = get_session()
-
         school = session.query(School).get(item.info['id'])
         if school:
             session.query(School).filter_by(id=item.info['id']).update({**item.info, 'raw': item.item})
@@ -55,7 +56,6 @@ class DatabasePipeline(object):
     def process_item(self, item, spider):
         school = School.update_or_create(item)
         try:
-            session = get_session()
             session.add(school)
             session.commit()
         except SQLAlchemyError as e:

--- a/test_models.py
+++ b/test_models.py
@@ -1,13 +1,11 @@
-import os
 import unittest
-from unittest import mock
 
 from scrapy import Item
 from scrapy.item import Field
 
 from jedeschule.items import School
 from jedeschule.pipelines.school_pipeline import SchoolPipelineItem
-from jedeschule.pipelines.db_pipeline import School as DBSchool, get_session
+from jedeschule.pipelines.db_pipeline import School as DBSchool, session
 
 
 class TestSchoolItem(Item):
@@ -15,7 +13,6 @@ class TestSchoolItem(Item):
     nr = Field()
 
 
-@mock.patch.dict(os.environ, {'DATABASE_URL': 'sqlite://'})
 class TestSchool(unittest.TestCase):
     def test_import_new(self):
         # Arrange
@@ -23,7 +20,6 @@ class TestSchool(unittest.TestCase):
         item = dict(name='Test Schule', nr=1)
         school_item: SchoolPipelineItem = SchoolPipelineItem(info=info, item=item)
         db_item = DBSchool.update_or_create(school_item)
-        session = get_session()
         session.add(db_item)
         session.commit()
 
@@ -41,7 +37,6 @@ class TestSchool(unittest.TestCase):
         item = dict(name='Test Schule', nr=1)
         school_item: SchoolPipelineItem = SchoolPipelineItem(info=info, item=item)
         db_item = DBSchool.update_or_create(school_item)
-        session = get_session()
         session.add(db_item)
         session.commit()
 


### PR DESCRIPTION
This is required because SQLAlchemy will ensure that an object
coming from the database does not change sessions. In the previous
implementation, if an item existed already, we would find it in the
database from `update_or_create` from which it would bring its session.
We would then try to add it to the session crated in `process_item`
which would fail.
Since both methods exist in the same module though, they can simply
share a module-global session.
Changing it to this allows us to update entries that already exist
in the database.