### PR TITLE
Install wheel in CI test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
+      - run: pip install wheel
       - run: pip install -r requirements.txt
       - run: ./test.sh

--- a/.github/workflows/test_scraper_changes.yml
+++ b/.github/workflows/test_scraper_changes.yml
@@ -16,5 +16,6 @@ jobs:
           python-version: 3.8
           architecture: x64
       - run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
+      - run: pip install wheel
       - run: pip install -r requirements.txt
       - run: ./test_changes.sh


### PR DESCRIPTION
This is because currently our build always says:
```
Using legacy 'setup.py install' for <package>, since package 'wheel' is not installed.
```