### PR TITLE
Fail in test script if any step fails

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 touch /tmp/jedeschule-test.sqlite
 
 export DATABASE_URL=sqlite:////tmp/jedeschule-test.sqlite


### PR DESCRIPTION
We need to make sure that the test is marked as failed
if any step in the test script fails.
Otherwise we might have a run in which the actual python
tests fail but we don't notice because the script continues
and the last line that gets run exits with a success exit code.

See for example here: https://github.com/Datenschule/jedeschule-scraper/runs/1754916865