### PR TITLE
Use scrapinghub 2.4 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scrapinghub/scrapinghub-stack-scrapy:1.8-py3
+FROM scrapinghub/scrapinghub-stack-scrapy:2.4
 
 COPY . .
 


### PR DESCRIPTION
2.4 is the version that we now require in our
`requirements.txt` so we should use a base image
that matches this.