### PR TITLE
[SH] make address null-safe

### DIFF
--- a/jedeschule/spiders/schleswig_holstein.py
+++ b/jedeschule/spiders/schleswig_holstein.py
@@ -20,7 +20,7 @@ class SchleswigHolsteinSpider(SchoolSpider):
     def normalize(item: Item) -> School:
         return School(name=item.get('name'),
                       id='SH-{}'.format(item.get('id')),
-                      address=" ".join([item.get('street'), item.get('houseNumber')]),
+                      address=" ".join([item.get('street') or "", item.get('houseNumber') or ""]).strip(),
                       zip=item.get("zipcode"),
                       city=item.get("city"),
                       email=item.get('email'),

--- a/jedeschule/spiders/schleswig_holstein.py
+++ b/jedeschule/spiders/schleswig_holstein.py
@@ -20,7 +20,7 @@ class SchleswigHolsteinSpider(SchoolSpider):
     def normalize(item: Item) -> School:
         return School(name=item.get('name'),
                       id='SH-{}'.format(item.get('id')),
-                      address=" ".join([item.get('street') or "", item.get('houseNumber') or ""]).strip(),
+                      address=" ".join([item.get('street', ""), item.get('houseNumber',  "")]).strip(),
                       zip=item.get("zipcode"),
                       city=item.get("city"),
                       email=item.get('email'),


### PR DESCRIPTION
The spider for Schleswig-Holstein ran into an error because of an empty house number.
This PR makes the address extraction more robust.