### PR TITLE
Fix deprecation warning for `process_item`

### DIFF
--- a/jedeschule/pipelines/db_pipeline.py
+++ b/jedeschule/pipelines/db_pipeline.py
@@ -73,7 +73,7 @@ class DatabasePipeline:
     def __init__(self):
         self.session = get_session()
 
-    def process_item(self, item: SchoolPipelineItem, spider):
+    def process_item(self, item: SchoolPipelineItem):
         school = School.update_or_create(item, session=self.session)
         try:
             self.session.add(school)

--- a/jedeschule/pipelines/jsonpipeline.py
+++ b/jedeschule/pipelines/jsonpipeline.py
@@ -16,6 +16,6 @@ class JsonPipeline(object):
         self.exporter.finish_exporting()
         self.file.close()
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         self.exporter.export_item(item)
         return item

--- a/jedeschule/pipelines/school_pipeline.py
+++ b/jedeschule/pipelines/school_pipeline.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from scrapy import Item
 
 from jedeschule.items import School
-from jedeschule.spiders.school_spider import SchoolSpider
 
 
 @dataclass
@@ -12,7 +11,14 @@ class SchoolPipelineItem:
     item: Item
 
 
-class SchoolPipeline(object):
-    def process_item(self, item, spider: SchoolSpider) -> SchoolPipelineItem:
-        school = spider.normalize(item)
+class SchoolPipeline:
+    def __init__(self, crawler):
+        self.crawler = crawler
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
+    def process_item(self, item) -> SchoolPipelineItem:
+        school = self.crawler.spider.normalize(item)
         return SchoolPipelineItem(info=school, item=item)


### PR DESCRIPTION
`spider` will not be passed as an arugment in future versions so we need to store it in the newly
recommended way via `from_crawler`.

The error that we used to get was:

```
2026-05-27 14:39:08 [py.warnings] WARNING: <path>/.venv/lib/python3.12/site-packages/scrapy/pipelines/__init__.py:49: ScrapyDeprecationWarning: SchoolPipeline.process_item() requires a spider argument, this is deprecated and the argument will not be passed in future Scrapy versions. If you need to access the spider instance you can save the crawler instance passed to from_crawler() and use its spider attribute.
  self._check_mw_method_spider_arg(pipe.process_item)
```